### PR TITLE
Notify for missing user assignments

### DIFF
--- a/src/DataSelector/ForecastDataSelector.php
+++ b/src/DataSelector/ForecastDataSelector.php
@@ -215,7 +215,7 @@ class ForecastDataSelector
      * @param mixed|null $enabled
      * @param mixed|null $methodName
      *
-     * @return Client[]
+     * @return Project[]
      */
     public function getProjectsById($methodName = null, $enabled = null)
     {

--- a/src/DataSelector/HarvestDataSelector.php
+++ b/src/DataSelector/HarvestDataSelector.php
@@ -281,6 +281,25 @@ class HarvestDataSelector
         return $uninvoiced;
     }
 
+    public function getUserAssignments(array $options = []): array
+    {
+        $result = [];
+        $assignments = $this->client->listUserAssignments($options, 'userAssignments')->getUserAssignments();
+
+        foreach ($assignments as $assignment) {
+            $userId = $assignment->getUser()->getId();
+            $projectId = $assignment->getProject()->getId();
+
+            if (!isset($result[$userId])) {
+                $result[$userId] = [];
+            }
+
+            $result[$userId][$projectId] = $assignment;
+        }
+
+        return $result;
+    }
+
     public function getUserTimeEntries(\DateTime $from, \DateTime $to, array $options = []): array
     {
         $result = [];

--- a/src/Harvest/Handler.php
+++ b/src/Harvest/Handler.php
@@ -132,11 +132,13 @@ class Handler
                 $value
             );
             try {
+                $current = (new \DateTime($value))->format('n') === (new \DateTime())->format('n');
                 $this->updateReminder(
                     $harvestProperties['account'],
                     $harvestProperties['user'],
                     $payload['trigger_id'],
-                    $payload['response_url']
+                    $payload['response_url'],
+                    $current
                 );
             } catch (\Exception $e) {
                 // silence, the initial reminder might be sent since a long time

--- a/src/Harvest/Reminder.php
+++ b/src/Harvest/Reminder.php
@@ -333,7 +333,7 @@ class Reminder
     {
         $blocks = [];
 
-        if (count($issues['no_harvest_project']) + count($issues['missing_harvest_user_assignment']) > 0) {
+        if (\count($issues['no_harvest_project']) + \count($issues['missing_harvest_user_assignment']) > 0) {
             $blocks = [
                 [
                     'type' => 'section',
@@ -347,7 +347,7 @@ class Reminder
             ];
         }
 
-        if (count($issues['no_harvest_project']) > 0) {
+        if (\count($issues['no_harvest_project']) > 0) {
             $blocks[] = [
                 'type' => 'section',
                 'text' => [
@@ -371,7 +371,7 @@ class Reminder
             ];
         }
 
-        if (count($issues['missing_harvest_user_assignment']) > 0) {
+        if (\count($issues['missing_harvest_user_assignment']) > 0) {
             $blocks[] = [
                 'type' => 'section',
                 'text' => [
@@ -413,7 +413,6 @@ class Reminder
 
         return $blocks;
     }
-
 
     private function buildSlackBlocks(array $issues, $currentMonth = false): array
     {

--- a/src/Harvest/Reminder.php
+++ b/src/Harvest/Reminder.php
@@ -57,14 +57,31 @@ class Reminder
         $harvestAccounts = $this->harvestAccountRepository->findAllHavingTimesheetReminderSlackTeam();
 
         foreach ($harvestAccounts as $harvestAccount) {
+            $missingProjectAssignmentsIssues = $this->buildMissingItemsSlackBlocks(
+                $this->buildMissingProjectAssignmentsIssues($harvestAccount, $firstDayOfLastMonth, $lastDayOfLastMonth),
+                $harvestAccount
+            );
             $issues = $this->buildSlackBlocks(
                 $this->buildIssues($harvestAccount, $firstDayOfLastMonth, $lastDayOfLastMonth)
             );
 
-            if (\count($issues) > 0) {
+            if (\count($issues) + \count($missingProjectAssignmentsIssues) > 0) {
                 $slackClient = \JoliCode\Slack\ClientFactory::create(
                     $harvestAccount->getTimesheetReminderSlackTeam()->getSlackTeam()->getAccessToken()
                 );
+
+                if (\count($missingProjectAssignmentsIssues)) {
+                    $adminUsers = $this->getHarvestAdminSlackIds($harvestAccount);
+
+                    foreach ($adminUsers as $adminUser) {
+                        $slackClient->chatPostMessage([
+                            'channel' => $adminUser,
+                            'username' => self::BOT_NAME,
+                            'text' => $missingProjectAssignmentsIssues[0]['text']['text'],
+                            'blocks' => json_encode($missingProjectAssignmentsIssues),
+                        ]);
+                    }
+                }
 
                 foreach ($issues as $issue) {
                     // send a Slack notification to this user
@@ -261,6 +278,142 @@ class Reminder
 
         return $issues;
     }
+
+    private function buildMissingProjectAssignmentsIssues(HarvestAccount $harvestAccount, \DateTime $firstDayOfLastMonth, \DateTime $lastDayOfLastMonth, HarvestUser $harvestUser = null): array
+    {
+        $issues = [
+            'no_harvest_project' => [],
+            'missing_harvest_user_assignment' => [],
+        ];
+        $slackTeam = $harvestAccount->getTimesheetReminderSlackTeam();
+
+        if (null === $slackTeam) {
+            return [];
+        }
+
+        $this->harvestDataSelector->setHarvestAccount($harvestAccount);
+        $this->forecastDataSelector->setForecastAccount($harvestAccount->getForecastAccount());
+        $forecastPeople = $this->forecastDataSelector->getPeopleById();
+        $forecastProjects = $this->forecastDataSelector->getProjectsById();
+        $harvestUserAssignments = $this->harvestDataSelector->getUserAssignments(['is_active' => true]);
+        $forecastAssignments = $this->forecastDataSelector->getAssignments($firstDayOfLastMonth, $lastDayOfLastMonth);
+
+        foreach ($forecastAssignments as $forecastAssignment) {
+            $forecastProject = $forecastProjects[$forecastAssignment->getProjectId()] ?? null;
+            $forecastPerson = $forecastPeople[$forecastAssignment->getPersonId()] ?? null;
+
+            if (!$forecastProject || !$forecastPerson || !$forecastPerson->getHarvestUserId()) {
+                continue;
+            }
+
+            if (!$forecastProject->getHarvestId()) {
+                $issues['no_harvest_project'][$forecastProject->getId()] = $forecastProject;
+            }
+
+            if (!isset($harvestUserAssignments[$forecastPerson->getHarvestUserId()])
+                || !isset($harvestUserAssignments[$forecastPerson->getHarvestUserId()][$forecastProject->getHarvestId()])) {
+                if (!isset($issues['missing_harvest_user_assignment'][$forecastPerson->getHarvestUserId()])) {
+                    $issues['missing_harvest_user_assignment'][$forecastPerson->getHarvestUserId()] = [
+                        'forecast_user' => $forecastPerson,
+                        'projects' => [],
+                    ];
+                }
+
+                $issues['missing_harvest_user_assignment'][$forecastPerson->getHarvestUserId()]['projects'][$forecastProject->getId()] = [
+                    'project' => $forecastProject,
+                    'assignment' => $forecastAssignment,
+                ];
+            }
+        }
+
+        return $issues;
+    }
+
+    private function buildMissingItemsSlackBlocks(array $issues, HarvestAccount $harvestAccount): array
+    {
+        $blocks = [];
+
+        if (count($issues['no_harvest_project']) + count($issues['missing_harvest_user_assignment']) > 0) {
+            $blocks = [
+                [
+                    'type' => 'section',
+                    'text' => [
+                        'type' => 'mrkdwn',
+                        'text' => 'There are some issues with in the Harvest projects configuration and assignments, that could prevent some of your users from filling their timesheets for last month.',
+                    ],
+                ], [
+                    'type' => 'divider',
+                ],
+            ];
+        }
+
+        if (count($issues['no_harvest_project']) > 0) {
+            $blocks[] = [
+                'type' => 'section',
+                'text' => [
+                    'type' => 'mrkdwn',
+                    'text' => 'Projects that exist in Slack and do not exist in Harvest',
+                ],
+            ];
+
+            foreach ($issues['no_harvest_project'] as $forecastProject) {
+                $blocks[] = [
+                    'type' => 'section',
+                    'text' => [
+                        'type' => 'mrkdwn',
+                        'text' => sprintf('[%s] %s', $forecastProject->getCode(), $forecastProject->getName()),
+                    ],
+                ];
+            }
+
+            $blocks[] = [
+                'type' => 'divider',
+            ];
+        }
+
+        if (count($issues['missing_harvest_user_assignment']) > 0) {
+            $blocks[] = [
+                'type' => 'section',
+                'text' => [
+                    'type' => 'mrkdwn',
+                    'text' => 'The following users are not assigned projects in Harvest, while they are in Forecast. They won\'t be able to fill their harvest timesheets:',
+                ],
+            ];
+
+            foreach ($issues['missing_harvest_user_assignment'] as $userIssues) {
+                $blocks[] = [
+                    'type' => 'section',
+                    'text' => [
+                        'type' => 'mrkdwn',
+                        'text' => sprintf('*%s %s*', $userIssues['forecast_user']->getFirstName(), $userIssues['forecast_user']->getLastName()),
+                    ],
+                ];
+
+                foreach ($userIssues['projects'] as $project) {
+                    $blocks[] = [
+                        'type' => 'section',
+                        'text' => [
+                            'type' => 'mrkdwn',
+                            'text' => sprintf(
+                                '<%s/projects/%s|[%s] %s>',
+                                $harvestAccount->getBaseUri(),
+                                $project['project']->getHarvestId(),
+                                $project['project']->getCode(),
+                                $project['project']->getName()
+                            ),
+                        ],
+                    ];
+                }
+            }
+
+            $blocks[] = [
+                'type' => 'divider',
+            ];
+        }
+
+        return $blocks;
+    }
+
 
     private function buildSlackBlocks(array $issues, $currentMonth = false): array
     {
@@ -466,6 +619,28 @@ class Reminder
 
             return 0 === \count($matchingAssignments);
         });
+    }
+
+    private function getHarvestAdminSlackIds(HarvestAccount $harvestAccount)
+    {
+        $ids = [];
+        $slackTeam = $harvestAccount->getTimesheetReminderSlackTeam();
+
+        if (null === $slackTeam) {
+            return $ids;
+        }
+
+        $slackUsers = $this->slackDataSelector->getUsersByEmail($slackTeam->getSlackTeam());
+        $this->harvestDataSelector->setHarvestAccount($harvestAccount);
+        $users = $this->harvestDataSelector->getEnabledUsers();
+
+        foreach ($users as $user) {
+            if ($user->getIsAdmin() && isset($slackUsers[$user->getEmail()])) {
+                $ids[] = $slackUsers[$user->getEmail()]->getId();
+            }
+        }
+
+        return $ids;
     }
 
     private function getClockEmoji($value)


### PR DESCRIPTION
￼Notify Harvest admins that some Harvest user assignments are missing and will prevent users from copying their timesheets from Forecast