### PR TITLE
have smaller public forecast URLs

### DIFF
--- a/src/Controller/Organization/PublicForecastController.php
+++ b/src/Controller/Organization/PublicForecastController.php
@@ -53,7 +53,7 @@ class PublicForecastController extends AbstractController
     public function create(Request $request, ForecastAccount $forecastAccount, UserRepository $userRepository, EntityManagerInterface $em)
     {
         $publicForecast = new PublicForecast();
-        $publicForecast->setToken(bin2hex(random_bytes(120)));
+        $publicForecast->setToken(bin2hex(random_bytes(80)));
         $user = $userRepository->findOneBy(['email' => $this->getUser()->getUsername()]);
         $publicForecast->setCreatedBy($user);
         $publicForecast->setForecastAccount($forecastAccount);


### PR DESCRIPTION
This should shorten the public forecast URLs of about 80 chars
fixes #59