### PR TITLE
Fix/redirect users when google signin required

### DIFF
--- a/src/Exception/RedirectException.php
+++ b/src/Exception/RedirectException.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of JoliCode's Forecast Tools project.
+ *
+ * (c) JoliCode <coucou@jolicode.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Exception;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class RedirectException extends HttpException
+{
+    /**
+     * @param string|null     $message  The internal exception message
+     * @param \Throwable|null $previous The previous exception
+     * @param int             $code     The internal exception code
+     */
+    public function __construct(string $location, ?string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
+    {
+        $headers['Location'] = $location;
+        parent::__construct(302, $message, $previous, $headers, $code);
+    }
+}

--- a/src/Security/HarvestAuthenticator.php
+++ b/src/Security/HarvestAuthenticator.php
@@ -16,6 +16,7 @@ use App\Entity\HarvestAccount;
 use App\Entity\User;
 use App\Entity\UserForecastAccount;
 use App\Entity\UserHarvestAccount;
+use App\Exception\RedirectException;
 use App\Repository\ForecastAccountRepository;
 use App\Repository\HarvestAccountRepository;
 use App\Repository\UserForecastAccountRepository;
@@ -206,7 +207,17 @@ class HarvestAuthenticator extends SocialAuthenticator
 
         if ($company instanceof \JoliCode\Harvest\Api\Model\Error) {
             // The company requires Google signin, which seems to break Harvest API...
-            return null;
+            // redirect the user to the Harvest authentication page requiring Google auth
+            throw new RedirectException(
+                sprintf(
+                    'https://id.getharvest.com/accounts/%s/google',
+                    $account['id']
+                ),
+                sprintf(
+                    'The "%s" harvest organization requires Google signin and the user did not signin that way.',
+                    $account['name']
+                )
+            );
         }
 
         $harvestAccount = $this->harvestAccountRepository->findOneBy(['harvestId' => $account['id']]);

--- a/src/Security/HarvestAuthenticator.php
+++ b/src/Security/HarvestAuthenticator.php
@@ -208,16 +208,7 @@ class HarvestAuthenticator extends SocialAuthenticator
         if ($company instanceof \JoliCode\Harvest\Api\Model\Error) {
             // The company requires Google signin, which seems to break Harvest API...
             // redirect the user to the Harvest authentication page requiring Google auth
-            throw new RedirectException(
-                sprintf(
-                    'https://id.getharvest.com/accounts/%s/google',
-                    $account['id']
-                ),
-                sprintf(
-                    'The "%s" harvest organization requires Google signin and the user did not signin that way.',
-                    $account['name']
-                )
-            );
+            throw new RedirectException(sprintf('https://id.getharvest.com/accounts/%s/google', $account['id']), sprintf('The "%s" harvest organization requires Google signin and the user did not signin that way.', $account['name']));
         }
 
         $harvestAccount = $this->harvestAccountRepository->findOneBy(['harvestId' => $account['id']]);


### PR DESCRIPTION
The use case: 
 * the user signed in to Harvest using is email / password
 * one of his Harvest organizations requires Google signin as the authentication method

Until now, we silently bypassed this Harvest organization, which meant the user would not see operations related to this Harvest organization in the forecast-tools interface (he would be able to perform Forecast-related tasks, not Harvest).