### PR TITLE
Fix missing Forecast allocations

### DIFF
--- a/src/Client/ForecastClient.php
+++ b/src/Client/ForecastClient.php
@@ -18,6 +18,7 @@ use JoliCode\Forecast\Client;
 use JoliCode\Forecast\ClientFactory;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Contracts\Cache\ItemInterface;
 
@@ -75,7 +76,7 @@ class ForecastClient extends AbstractClient
             $user = null;
             $forecastAccount = $this->getForecastAccount();
 
-            if ($this->security->getUser()) {
+            if ($this->security->getUser() && !($this->security->getToken() instanceof SwitchUserToken)) {
                 $email = $this->security->getUser()->getUserIdentifier();
                 $user = $this->userRepository->findOneBy(['email' => $email]);
             }

--- a/src/Client/HarvestClient.php
+++ b/src/Client/HarvestClient.php
@@ -18,6 +18,7 @@ use JoliCode\Harvest\Api\Model\Error;
 use JoliCode\Harvest\ClientFactory;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Contracts\Cache\ItemInterface;
 
@@ -83,10 +84,14 @@ class HarvestClient extends AbstractClient
         }
 
         if (null === $this->defaultClient) {
-            $email = $this->security->getUser()->getUserIdentifier();
-            $user = $this->userRepository->findOneBy(['email' => $email]);
+            $user = null;
             $forecastAccount = $this->requestStack->getCurrentRequest()->attributes->get('forecastAccount');
             $harvestAccount = $forecastAccount->getHarvestAccount();
+
+            if ($this->security->getUser() && !($this->security->getToken() instanceof SwitchUserToken)) {
+                $email = $this->security->getUser()->getUserIdentifier();
+                $user = $this->userRepository->findOneBy(['email' => $email]);
+            }
 
             if ($user) {
                 $accessToken = $user->getAccessToken();

--- a/src/Controller/Admin/ForecastAccountCrudController.php
+++ b/src/Controller/Admin/ForecastAccountCrudController.php
@@ -64,7 +64,6 @@ class ForecastAccountCrudController extends AbstractCrudController
             TextField::new('refreshToken')->onlyOnDetail(),
             BooleanField::new('refreshToken', 'Refreshable')
                 ->formatValue(function ($value): bool {
-                    dump($value);
                     return null !== $value;
                 })->setCustomOptions([
                     'renderAsSwitch' => false,

--- a/src/Controller/Admin/ForecastAccountCrudController.php
+++ b/src/Controller/Admin/ForecastAccountCrudController.php
@@ -62,7 +62,14 @@ class ForecastAccountCrudController extends AbstractCrudController
             BooleanField::new('allowNonAdmins', 'Allow non admins to create public forecasts')->hideOnIndex(),
             TextField::new('accessToken')->onlyOnDetail(),
             TextField::new('refreshToken')->onlyOnDetail(),
-            IntegerField::new('expires', 'token expiration')
+            BooleanField::new('refreshToken', 'Refreshable')
+                ->formatValue(function ($value): bool {
+                    dump($value);
+                    return null !== $value;
+                })->setCustomOptions([
+                    'renderAsSwitch' => false,
+                ]),
+            IntegerField::new('expires', 'Token expiration')
                 ->formatValue(function ($value): string {
                     $interval = ((new \DateTime())->setTimestamp($value))->diff(new \DateTime());
                     $mapping = [

--- a/src/Controller/Admin/UserCrudController.php
+++ b/src/Controller/Admin/UserCrudController.php
@@ -43,7 +43,7 @@ class UserCrudController extends AbstractCrudController
             EmailField::new('email')
                 ->setFormTypeOptions(['disabled' => 'disabled']),
             DateTimeField::new('createdAt')->hideOnForm(),
-            IntegerField::new('expires', 'token expiration')
+            IntegerField::new('expires', 'Token expiration')
                 ->hideOnForm()
                 ->formatValue(function ($value): string {
                     $interval = ((new \DateTime())->setTimestamp($value))->diff(new \DateTime());

--- a/src/Harvest/Reminder.php
+++ b/src/Harvest/Reminder.php
@@ -22,6 +22,7 @@ use JoliCode\Forecast\Api\Model\Assignment;
 use JoliCode\Harvest\Api\Model\TimeEntriesPostBody;
 use JoliCode\Harvest\Api\Model\TimeEntry;
 use JoliCode\Harvest\Api\Model\User as HarvestUser;
+use function Symfony\Component\String\u;
 
 class Reminder
 {
@@ -547,20 +548,34 @@ class Reminder
                 }
 
                 if (\count($detailsMessages) > 0) {
-                    $message = sprintf(
+                    $text = sprintf(
                         '📅 *<%s|Week starting on %s>*%s',
                         $weeklyIssue['link'],
                         $weeklyIssue['name'],
                         $this->buildHoursDiffSuffix($weeklyHoursDiff)
                     );
-                    $text = $message . "\n" . implode("\n", $detailsMessages);
 
-                    if (mb_strlen($text) > 2998) {
-                        $text = mb_substr($text, 0, 2997) . "…\n";
-                    } else {
-                        $text .= "\n";
+                    foreach ($detailsMessages as $message) {
+                        if (u($text)->length() + u($message)->length() < 2997) {
+                            $text .=  "\n".$message;
+                        } else {
+                            $block = [
+                                'type' => 'section',
+                                'text' => [
+                                    'type' => 'mrkdwn',
+                                    'text' => $text . "\n",
+                                ],
+                            ];
+                            if (null !== $accessory) {
+                                $block['accessory'] = $accessory;
+                                $accessory = null;
+                            }
+                            $blocks[] = $block;
+                            $text = $message;
+                        }
                     }
 
+                    $text .= "\n";
                     $block = [
                         'type' => 'section',
                         'text' => [

--- a/src/Harvest/Reminder.php
+++ b/src/Harvest/Reminder.php
@@ -557,7 +557,7 @@ class Reminder
 
                     foreach ($detailsMessages as $message) {
                         if (u($text)->length() + u($message)->length() < 2997) {
-                            $text .=  "\n".$message;
+                            $text .= "\n" . $message;
                         } else {
                             $block = [
                                 'type' => 'section',


### PR DESCRIPTION
In some edge cases, Forecast responses contain a `null` allocation. It also happens (though it should never be the case) that both personId and placeholderId are `null`