### PR TITLE
add a link to the Forecast Slack notification config page when an override is missing

### DIFF
--- a/src/ForecastReminder/Sender.php
+++ b/src/ForecastReminder/Sender.php
@@ -23,30 +23,20 @@ use JoliCode\Slack\Exception\SlackErrorResponse;
 
 class Sender
 {
-    private $botName;
-    private Builder $builder;
-    private EntityManagerInterface $em;
-    private ForecastAccountSlackTeamRepository $forecastAccountSlackTeamRepository;
-    private ForecastReminderRepository $forecastReminderRepository;
-    private Client $bugsnagClient;
+    private string $botName;
 
     public function __construct(
-        Builder $builder,
-        EntityManagerInterface $em,
-        ForecastAccountSlackTeamRepository $forecastAccountSlackTeamRepository,
-        ForecastReminderRepository $forecastReminderRepository,
-        Client $bugsnagClient)
-    {
-        $this->builder = $builder;
-        $this->em = $em;
-        $this->forecastAccountSlackTeamRepository = $forecastAccountSlackTeamRepository;
-        $this->forecastReminderRepository = $forecastReminderRepository;
-        $this->bugsnagClient = $bugsnagClient;
-    }
-
-    public function send()
+        private Builder $builder,
+        private EntityManagerInterface $em,
+        private ForecastAccountSlackTeamRepository $forecastAccountSlackTeamRepository,
+        private ForecastReminderRepository $forecastReminderRepository,
+        private Client $bugsnagClient)
     {
         $this->botName = $this->getFunnyBotName();
+    }
+
+    public function send(): int
+    {
         $forecastReminders = $this->forecastReminderRepository->findAll();
         $forecastRemindersCount = 0;
 
@@ -72,7 +62,7 @@ class Sender
         return $forecastRemindersCount;
     }
 
-    private function sendForecastReminder(ForecastReminder $forecastReminder)
+    private function sendForecastReminder(ForecastReminder $forecastReminder): void
     {
         $forecastAccountSlackTeams = $forecastReminder->getForecastAccount()->getForecastAccountSlackTeams();
 

--- a/src/Security/AuthenticationEntryPoint.php
+++ b/src/Security/AuthenticationEntryPoint.php
@@ -19,11 +19,8 @@ use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface
 
 class AuthenticationEntryPoint implements AuthenticationEntryPointInterface
 {
-    private $urlGenerator;
-
-    public function __construct(UrlGeneratorInterface $urlGenerator)
+    public function __construct(private UrlGeneratorInterface $urlGenerator)
     {
-        $this->urlGenerator = $urlGenerator;
     }
 
     public function start(Request $request, AuthenticationException $authException = null): RedirectResponse


### PR DESCRIPTION
When the daily Forecast Slack notification is missing some project name override (and when it uses at least one), add a link to the overrides configuration:

![Capture d’écran de 2022-09-21 09-51-53](https://user-images.githubusercontent.com/177293/191447206-a1221a8e-7340-40c0-86a0-0573e8fca73f.png)
