### PR TITLE
re-enable invoicing process colors

### DIFF
--- a/assets/css/invoicing-table.scss
+++ b/assets/css/invoicing-table.scss
@@ -28,18 +28,22 @@
         }
 
         &.ok {
+            --bs-table-bg: transparent;
             background-color: #efe;
         }
 
         &.wrong {
+            --bs-table-bg: transparent;
             background-color: #fdd;
         }
 
         &.notice {
+            --bs-table-bg: transparent;
             background-color: #ffe;
         }
 
         &.explained {
+            --bs-table-bg: transparent;
             background-color: #f8f8f8;
         }
     }

--- a/castor.php
+++ b/castor.php
@@ -71,7 +71,7 @@ function front_install(): void
     docker_compose_run('yarn');
 }
 
-#[AsTask(description: 'Run Yarn watcher', namespace: 'app:front')]
+#[AsTask(name: 'watch', description: 'Run Yarn watcher', namespace: 'app:front')]
 function front_watch(): void
 {
     docker_compose_run('yarn run watch');


### PR DESCRIPTION
override bootstrap's defaults to allow styling errors and notices in invoicng processes